### PR TITLE
disable webkit-column-count rule.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -268,7 +268,7 @@ h3 + .content {
 
 @media (min-width: 54em) {
   .content, .challenge {
-    -webkit-column-count: 2;
+    /*-webkit-column-count: 2;*/
        -moz-column-count: 2;
             column-count: 2;
     -webkit-column-gap: 2rem;


### PR DESCRIPTION
Fixes video controls on Chrome but breaks layout a bit.
